### PR TITLE
Use a subset of an addon’s package for generating its cache key

### DIFF
--- a/lib/calculate-cache-key-for-tree.js
+++ b/lib/calculate-cache-key-for-tree.js
@@ -5,8 +5,8 @@ const stringify = require('json-stable-stringify');
 
 /*
   Calculates the cache key for a given type of tree (e.g., addon, app, etc.) for
-  a given instance of an Addon. By default, uses the addon's package.json and
-  name to generate the cache key.
+  a given instance of an Addon. By default, uses members of the addon's
+  package.json and name to generate the cache key.
 
   @public
   @method calculateCacheKeyForTree
@@ -16,10 +16,18 @@ const stringify = require('json-stable-stringify');
   @return {String} cacheKey
 */
 module.exports = function calculateCacheKeyForTree(treeType, addonInstance, additionalCacheKeyParts) {
+  let pkg = addonInstance.pkg || {};
+
   let cacheKeyParts = [
-    addonInstance.pkg,
     addonInstance.name,
-    treeType
+    treeType,
+    pkg.name,
+    pkg.version,
+    pkg.dependencies,
+    pkg.devDependencies,
+    pkg.peerDependencies,
+    pkg.bundledDependencies,
+    pkg.optionalDependencies
   ].concat(additionalCacheKeyParts);
 
   return crypto.createHash('md5').update(stringify(cacheKeyParts), 'utf8').digest('hex');

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ describe('calculateCacheKeyForTree', function() {
   it('should return same value for same input', function() {
     var addon = {
       root: 'hoy',
-      pkg: { some: 'parsed', value: { goes: 'here' }}
+      pkg: { name: 'foo', dependencies: { bar: '1.2.3' } }
     };
 
     var first = calculateCacheKeyForTree('app', addon);
@@ -22,13 +22,13 @@ describe('calculateCacheKeyForTree', function() {
     var firstAddon = {
       name: 'derp',
       root: 'hoy',
-      pkg: { some: 'other', value: { goes: 'elsewhere' }}
+      pkg: { name: 'baz', dependencies: { bar: '2.0.1' } }
     };
 
     var secondAddon = {
       name: 'huzzah',
       root: 'hoy',
-      pkg: { some: 'parsed', value: { goes: 'here' }}
+      pkg: { name: 'foo', dependencies: { bar: '1.2.3' } }
     };
 
     var first = calculateCacheKeyForTree('app', firstAddon);
@@ -40,7 +40,7 @@ describe('calculateCacheKeyForTree', function() {
   it('should not return same value for same addon with different tree type', function() {
     var addon = {
       root: 'hoy',
-      pkg: { some: 'parsed', value: { goes: 'here' }}
+      pkg: { name: 'foo', dependencies: { bar: '1.2.3' } }
     };
 
     var first = calculateCacheKeyForTree('addon', addon);
@@ -52,7 +52,7 @@ describe('calculateCacheKeyForTree', function() {
   it('should allow additional custom values to be passed', function() {
     var addon = {
       root: 'hoy',
-      pkg: { some: 'parsed', value: { goes: 'here' }}
+      pkg: { name: 'foo', dependencies: { bar: '1.2.3' } }
     };
 
     var first = calculateCacheKeyForTree('addon', addon);
@@ -64,7 +64,7 @@ describe('calculateCacheKeyForTree', function() {
   it('cache key parts are stable sorted', function() {
     var addon = {
       root: 'hoy',
-      pkg: { some: 'parsed', value: { goes: 'here' }}
+      pkg: { name: 'foo', dependencies: { bar: '1.2.3' } }
     };
 
     var first = calculateCacheKeyForTree('addon', addon, [ { foo: 'bar', baz: 'derp' }]);
@@ -91,7 +91,7 @@ describe('cacheKeyForStableTree', function() {
     let addon = {
       name: 'derp',
       root: 'hoy',
-      pkg: { some: 'other', value: { goes: 'elsewhere' }},
+      pkg: { name: 'baz', dependencies: { bar: '2.0.1' } },
       cacheKeyForTree: cacheKeyForStableTree
     };
     let firstKey = addon.cacheKeyForTree('foo');


### PR DESCRIPTION
`calculateCacheKeyForTree` has been using the entirety of an addon’s `package.json` parsed contents (available as `addonInstance.pkg`) in generating a unique cache key.

The package spec has has reserved properties with `_` and `$` prefixes for package registries to use at their discretion (see http://wiki.commonjs.org/wiki/Packages/1.1). `npm` has begun to take advantage of this by embedding properties that are completely unique to the package (such as its parent). This of course defeats the entire purpose of the cache key.

Therefore, this change moves the implementation to only rely on certain properties that signal the uniqueness of an addon: its version, name, and dependencies (of all forms). This avoids the potential problems with private properties, and should be a bit faster to hash as well.