### PR TITLE
Change cache key algo (use full package.json but exclude _ or $ props).

### DIFF
--- a/lib/calculate-cache-key-for-tree.js
+++ b/lib/calculate-cache-key-for-tree.js
@@ -18,17 +18,14 @@ const stringify = require('json-stable-stringify');
 module.exports = function calculateCacheKeyForTree(treeType, addonInstance, additionalCacheKeyParts) {
   let pkg = addonInstance.pkg || {};
 
-  let cacheKeyParts = [
-    addonInstance.name,
-    treeType,
-    pkg.name,
-    pkg.version,
-    pkg.dependencies,
-    pkg.devDependencies,
-    pkg.peerDependencies,
-    pkg.bundledDependencies,
-    pkg.optionalDependencies
-  ].concat(additionalCacheKeyParts);
+  let cacheKeyParts = Object.keys(pkg)
+    .filter(k => k[0] !== '_' && k[0] !== '$')
+    .map(k => pkg[k])
+    .concat(
+      addonInstance.name,
+      treeType,
+      additionalCacheKeyParts
+    );
 
   return crypto.createHash('md5').update(stringify(cacheKeyParts), 'utf8').digest('hex');
 };

--- a/test.js
+++ b/test.js
@@ -18,6 +18,44 @@ describe('calculateCacheKeyForTree', function() {
     expect(first).to.equal(second);
   });
 
+  it('should return same value for different instances but same package.json content', function() {
+    var firstAddon = {
+      name: 'derp',
+      root: 'hoy',
+      pkg: { name: 'foo', dependencies: { bar: '2.0.1' } }
+    };
+
+    var secondAddon = {
+      name: 'derp',
+      root: 'hoy',
+      pkg: { name: 'foo', dependencies: { bar: '2.0.1' } }
+    };
+
+    var first = calculateCacheKeyForTree('app', firstAddon);
+    var second = calculateCacheKeyForTree('app', secondAddon);
+
+    expect(first).to.equal(second);
+  });
+
+  it('should return different value for addons with custom non-underscored keys in package.json', function() {
+    var firstAddon = {
+      name: 'huzzah',
+      root: 'hoy',
+      pkg: { name: 'foo', specialThing: 'quux', dependencies: { bar: '2.0.1' } }
+    };
+
+    var secondAddon = {
+      name: 'huzzah',
+      root: 'hoy',
+      pkg: { name: 'foo', specialThing: 'qux', dependencies: { bar: '2.0.1' } }
+    };
+
+    var first = calculateCacheKeyForTree('app', firstAddon);
+    var second = calculateCacheKeyForTree('app', secondAddon);
+
+    expect(first).to.not.equal(second);
+  });
+
   it('should return different value for different addons', function() {
     var firstAddon = {
       name: 'derp',


### PR DESCRIPTION
The prior change (in #14) made all properties _other_ than `name`, `version` `dependencies`, `devDependencies`, `peerDependencies`, and `optionalDependencies` ignored from the cache key generation.

However, after landing + releasing we identified a few scenarios where other properties in the package.json _do_ need to affect the cache key of the resulting addon trees (e.g. config for babel, rollup, types, main, ember-addon key, etc).

This change tweaks things such that we _only_ ignore `_` or `$` properties.